### PR TITLE
BUGZILLA 1593 - Mandantenkürzel zur SynTAX-Belegnummer hinzugefügt

### DIFF
--- a/sql/create_mckoi.sql
+++ b/sql/create_mckoi.sql
@@ -131,6 +131,7 @@ CREATE TABLE mandant (
   steuernummer varchar(100) NULL,
   waehrung varchar(10) NULL,
   finanzamt_id int(10) NOT NULL,
+  kuerzel varchar(10) NULL,
   UNIQUE (id),
   PRIMARY KEY (id)
 );

--- a/sql/create_mysql.sql
+++ b/sql/create_mysql.sql
@@ -131,6 +131,7 @@ CREATE TABLE IF NOT EXISTS mandant (
   steuernummer varchar(100) NULL,
   waehrung varchar(10) NULL,
   finanzamt_id int(10) NOT NULL,
+  kuerzel varchar(10) NULL,
   UNIQUE (id),
   PRIMARY KEY (id)
 ) ENGINE = InnoDB;

--- a/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListPart.java
+++ b/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListPart.java
@@ -24,6 +24,7 @@ import de.willuhn.jameica.fibu.rmi.Buchung;
 import de.willuhn.jameica.gui.extension.Extendable;
 import de.willuhn.jameica.gui.extension.Extension;
 import de.willuhn.jameica.gui.formatter.Formatter;
+import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
@@ -52,7 +53,7 @@ public class UmsatzListPart implements Extension
     this.cache = null; // Cache loeschen, damit die Daten neu gelesen werden
     
     TablePart table = (TablePart) extendable;
-    table.addColumn(i18n.tr("SynTAX-Beleg"),"id-int", new Formatter() {
+    Column col = new Column("id-int", i18n.tr("SynTAX-Beleg") ,new Formatter() {
       public String format(Object o)
       {
         if (o == null || !(o instanceof Integer))
@@ -74,7 +75,9 @@ public class UmsatzListPart implements Extension
         return null;
       }
     
-    });
+    }, false, Column.ALIGN_AUTO, Column.SORT_BY_DISPLAY);
+
+    table.addColumn(col);
   }
   
   /**

--- a/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListPart.java
+++ b/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListPart.java
@@ -59,11 +59,13 @@ public class UmsatzListPart implements Extension
           return null;
 
         Buchung b = getCache().get(o.toString());
+
         if (b == null)
           return null;
         try
         {
-          return Integer.toString(b.getBelegnummer());
+          String kuerzel = b.getGeschaeftsjahr().getMandant().getKuerzel();
+          return String.format("%s%04d", kuerzel, b.getBelegnummer());
         }
         catch (RemoteException re)
         {

--- a/src/de/willuhn/jameica/fibu/gui/controller/MandantControl.java
+++ b/src/de/willuhn/jameica/fibu/gui/controller/MandantControl.java
@@ -50,6 +50,7 @@ public class MandantControl extends AbstractControl
 	private Input ort									= null;
 	private Input steuernummer				= null;
   private Input waehrung            = null;
+	private Input kuerzel            = null;
 	private Input finanzamtAuswahl		= null;
 
 
@@ -96,6 +97,21 @@ public class MandantControl extends AbstractControl
     
     waehrung = new TextInput(getMandant().getWaehrung());
     return waehrung;
+  }
+
+
+  /**
+   * Liefert das Eingabe-Feld fuer die Waehrung.
+   * @return Eingabe-Feld.
+   * @throws RemoteException
+   */
+  public Input getKuerzel() throws RemoteException
+  {
+    if (kuerzel != null)
+      return kuerzel;
+
+    kuerzel = new TextInput(getMandant().getKuerzel());
+    return kuerzel;
   }
 
   /**
@@ -248,11 +264,12 @@ public class MandantControl extends AbstractControl
 
       getMandant().setName1((String)getName1().getValue());
       getMandant().setName2((String)getName2().getValue());
-			getMandant().setFirma((String)getFirma().getValue());
-			getMandant().setStrasse((String)getStrasse().getValue());
-			getMandant().setPLZ((String)getPLZ().getValue());
-			getMandant().setOrt((String)getOrt().getValue());
-			getMandant().setSteuernummer((String)getSteuernummer().getValue());
+      getMandant().setFirma((String)getFirma().getValue());
+      getMandant().setStrasse((String)getStrasse().getValue());
+      getMandant().setPLZ((String)getPLZ().getValue());
+      getMandant().setOrt((String)getOrt().getValue());
+      getMandant().setSteuernummer((String)getSteuernummer().getValue());
+      getMandant().setKuerzel((String)getKuerzel().getValue());
 
       
       // und jetzt speichern wir.

--- a/src/de/willuhn/jameica/fibu/gui/views/FirstStart3CreateMandant.java
+++ b/src/de/willuhn/jameica/fibu/gui/views/FirstStart3CreateMandant.java
@@ -68,6 +68,7 @@ public class FirstStart3CreateMandant extends AbstractView
       group.addLabelPair(i18n.tr("Finanzamt"),    control.getMandantControl().getFinanzamtAuswahl());
       group.addLabelPair(i18n.tr("Steuernummer"), control.getMandantControl().getSteuernummer());
       group.addLabelPair(i18n.tr("Währungsbezeichnung"), control.getMandantControl().getWaehrung());
+      group.addLabelPair(i18n.tr("Mandantenkürzel"), control.getMandantControl().getKuerzel());
     }
 
     ButtonArea buttons = group.createButtonArea(1);

--- a/src/de/willuhn/jameica/fibu/gui/views/MandantNeu.java
+++ b/src/de/willuhn/jameica/fibu/gui/views/MandantNeu.java
@@ -83,6 +83,7 @@ public class MandantNeu extends AbstractView
     group2.addLabelPair(i18n.tr("Finanzamt"),		control.getFinanzamtAuswahl());
     group2.addLabelPair(i18n.tr("Steuernummer"),	control.getSteuernummer());
     group2.addLabelPair(i18n.tr("Währungsbezeichnung"), control.getWaehrung());
+    group2.addLabelPair(i18n.tr("Mandantenkürzel"),	control.getKuerzel());
 
     ButtonArea buttonArea = new ButtonArea();
     

--- a/src/de/willuhn/jameica/fibu/rmi/Mandant.java
+++ b/src/de/willuhn/jameica/fibu/rmi/Mandant.java
@@ -172,6 +172,20 @@ public interface Mandant extends DBObject
    * @throws RemoteException
    */
   public void setWaehrung(String waehrung) throws RemoteException;
+
+  /**
+   * Liefert das Mandatenkürzel.
+   * @return Waehrung.
+   * @throws RemoteException
+   */
+  public String getKuerzel() throws RemoteException;
+
+  /**
+   * Legt das Mandatenkürzelfest.
+   * @param waehrung
+   * @throws RemoteException
+   */
+  public void setKuerzel(String waehrung) throws RemoteException;
 }
 
 

--- a/src/de/willuhn/jameica/fibu/server/MandantImpl.java
+++ b/src/de/willuhn/jameica/fibu/server/MandantImpl.java
@@ -254,6 +254,26 @@ public class MandantImpl extends AbstractDBObject implements Mandant
     setAttribute("waehrung",waehrung);
   }
 
+
+  /**
+   * @see de.willuhn.jameica.fibu.rmi.Mandant#getKuerzel()
+   */
+  public String getKuerzel() throws RemoteException
+  {
+    String s = (String) getAttribute("kuerzel");
+    if (s != null && s.length() > 0)
+      return s;
+    return "";
+  }
+
+  /**
+   * @see de.willuhn.jameica.fibu.rmi.Mandant#setKuerzel(java.lang.String)
+   */
+  public void setKuerzel(String kuerzel) throws RemoteException
+  {
+    setAttribute("kuerzel",kuerzel);
+  }
+
   /**
    * @see de.willuhn.jameica.fibu.rmi.Mandant#getGeschaeftsjahre()
    */


### PR DESCRIPTION
Ich habe einfach mal für mich die Idee aus BUGZILLA 1593 umgesetzt, da ich auf die eindeutigen Buchungs- Ids zwecks eindeutiger Verweise aus anderen Dokumenten angewiesen bin. Um eine Sortierbarkeit zu gewährleisten, wurden führende Nullen eingefügt. Deren Anzahl könnte sehr leicht auch konfigurierbar gemacht werden (vielleicht mache ich das in den nächsten Tagen).

Bislang habe ich auch in einer Umgebung mit echten Daten noch keine negativen Effekte der Änderung festgestellt, Testumgebung war eine MySQL-Datenbank, deren Schema manuell erweitert wurde. Das Update bestehender Datenbanken ist also noch ungelöst.

![image](https://cloud.githubusercontent.com/assets/3057137/5683692/42aa5484-982a-11e4-9d9a-fcd5fcac663c.png)


![image](https://cloud.githubusercontent.com/assets/3057137/5683766/e2779e9a-982a-11e4-9686-60ed7aaa82bc.png)
