### PR TITLE
VersionImpl erstellt um auch die Versions Tabelle umziehen zu können

### DIFF
--- a/src/de/willuhn/jameica/fibu/migration/AbstractDatabaseMigrationTask.java
+++ b/src/de/willuhn/jameica/fibu/migration/AbstractDatabaseMigrationTask.java
@@ -22,6 +22,7 @@ import de.willuhn.jameica.fibu.rmi.Kontoart;
 import de.willuhn.jameica.fibu.rmi.Kontotyp;
 import de.willuhn.jameica.fibu.rmi.Mandant;
 import de.willuhn.jameica.fibu.rmi.Steuer;
+import de.willuhn.jameica.fibu.rmi.Version;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.logging.Logger;
@@ -95,13 +96,14 @@ public abstract class AbstractDatabaseMigrationTask implements BackgroundTask
       failCount += copy(source,target,monitor,Anlagevermoegen.class);
       failCount += copy(source,target,monitor,Anfangsbestand.class);
       failCount += copy(source,target,monitor,Abschreibung.class);
+      failCount += copy(source,target,monitor,Version.class);
       Logger.info("finished data migration");
       Logger.info("################################################");
  
       if(failCount > 0)
       {
         monitor.setStatus(ProgressMonitor.STATUS_ERROR);
-        monitor.setStatusText(i18n.tr("Abgeschlossen. {0} Datensätze konnten nicht kopiert werden"));
+        monitor.setStatusText(i18n.tr("Abgeschlossen. {0} Datensätze konnten nicht kopiert werden",Integer.toString(failCount)));
       }
       else
       {

--- a/src/de/willuhn/jameica/fibu/rmi/Version.java
+++ b/src/de/willuhn/jameica/fibu/rmi/Version.java
@@ -1,0 +1,21 @@
+/**********************************************************************
+*
+* Copyright (c) 2004 Olaf Willuhn
+* All rights reserved.
+* 
+* This software is copyrighted work licensed under the terms of the
+* Jameica License.  Please consult the file "LICENSE" for details. 
+*
+**********************************************************************/
+package de.willuhn.jameica.fibu.rmi;
+
+import de.willuhn.datasource.rmi.DBObject;
+
+/**
+* Diese Klasse bildet die Datenbank Versionen in Fibu ab.
+* @author willuhn
+*/
+public interface Version extends DBObject
+{
+
+}

--- a/src/de/willuhn/jameica/fibu/server/VersionImpl.java
+++ b/src/de/willuhn/jameica/fibu/server/VersionImpl.java
@@ -1,0 +1,28 @@
+package de.willuhn.jameica.fibu.server;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.datasource.db.AbstractDBObject;
+import de.willuhn.jameica.fibu.rmi.Version;
+
+public class VersionImpl extends AbstractDBObject implements Version{
+
+	/**
+	   * Erzeugt eine neue Version.
+	   * @throws RemoteException
+	   */
+	public VersionImpl() throws RemoteException {
+		super();
+	}
+
+	@Override
+	protected String getTableName() {
+		return "version";
+	}
+
+	@Override
+	public String getPrimaryAttribute() throws RemoteException {
+		return "name";
+	}
+
+}


### PR DESCRIPTION
So Steht nun auch immer die Richitige Version in der DB. sonst kann es sein, dass Updatescripte ausgeführt werden die schon in create.sql enthalten sind. Wenn die Datenbank erst aktualisiert wind nachdem noch neue Versionen mit Updatescript dazugekommen sind. 