### PR TITLE
Hibiscus-Konten Syntax-Konten zuordnen für die Buchungsuebernahme.

### DIFF
--- a/sql/create_htwo.sql
+++ b/sql/create_htwo.sql
@@ -174,6 +174,16 @@ CREATE TABLE abschreibung (
   PRIMARY KEY (id)
 );
 
+CREATE TABLE kontozuordnung (
+  id IDENTITY(1),
+  name varchar(255) NOT NULL,
+  mandant_id int(10) NOT NULL,
+  konto_id int(10) NOT NULL,
+  hb_konto_id int(10) NOT NULL,
+  UNIQUE (id),
+  PRIMARY KEY (id)
+);
+
 CREATE INDEX idx_kr_mandant           ON kontenrahmen(mandant_id);
 
 CREATE INDEX idx_steuer_steuerkonto   ON steuer(steuerkonto_id);
@@ -254,3 +264,7 @@ ALTER TABLE geschaeftsjahr ADD CONSTRAINT fk_gj_self FOREIGN KEY (vorjahr_id) RE
 
 ALTER TABLE abschreibung ADD CONSTRAINT fk_abschreibung_av FOREIGN KEY (av_id) REFERENCES anlagevermoegen (id) DEFERRABLE;
 ALTER TABLE abschreibung ADD CONSTRAINT fk_abschreibung_buchung FOREIGN KEY (buchung_id) REFERENCES buchung (id) DEFERRABLE;
+
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_konto FOREIGN KEY (konto_id) REFERENCES konto (id) DEFERRABLE;
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_mandant FOREIGN KEY (mandant_id) REFERENCES mandant (id) DEFERRABLE;
+

--- a/sql/create_mckoi.sql
+++ b/sql/create_mckoi.sql
@@ -174,6 +174,16 @@ CREATE TABLE abschreibung (
   PRIMARY KEY (id)
 );
 
+CREATE TABLE kontozuordnung (
+  id NUMERIC default UNIQUEKEY('kontozuordnung'),
+  name varchar(255) NOT NULL,
+  mandant_id int(10) NOT NULL,
+  konto_id int(10) NOT NULL,
+  hb_konto_id int(10) NOT NULL,
+  UNIQUE (id), 
+  PRIMARY KEY (id)
+);
+  
 CREATE INDEX idx_kr_mandant           ON kontenrahmen(mandant_id);
 
 CREATE INDEX idx_steuer_steuerkonto   ON steuer(steuerkonto_id);
@@ -254,3 +264,6 @@ ALTER TABLE geschaeftsjahr ADD CONSTRAINT fk_gj_self FOREIGN KEY (vorjahr_id) RE
 
 ALTER TABLE abschreibung ADD CONSTRAINT fk_abschreibung_av FOREIGN KEY (av_id) REFERENCES anlagevermoegen (id) DEFERRABLE;
 ALTER TABLE abschreibung ADD CONSTRAINT fk_abschreibung_buchung FOREIGN KEY (buchung_id) REFERENCES buchung (id) DEFERRABLE;
+
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_konto FOREIGN KEY (konto_id) REFERENCES konto (id) DEFERRABLE;
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_mandant FOREIGN KEY (mandant_id) REFERENCES mandant (id) DEFERRABLE;

--- a/sql/create_mysql.sql
+++ b/sql/create_mysql.sql
@@ -174,6 +174,16 @@ CREATE TABLE IF NOT EXISTS abschreibung (
   PRIMARY KEY (id)
 ) ENGINE = InnoDB;
 
+CREATE TABLE IF NOT EXISTS kontozuordnung (
+  id int(10) NOT NULL AUTO_INCREMENT,
+  name varchar(255) NOT NULL,
+  mandant_id int(10) NOT NULL,
+  konto_id int(10) NOT NULL,
+  hb_konto_id int(10) NOT NULL,
+  UNIQUE (id),
+  PRIMARY KEY (id)
+) ENGINE = InnoDB;
+  
 CREATE INDEX idx_kr_mandant           ON kontenrahmen(mandant_id);
 
 CREATE INDEX idx_steuer_steuerkonto   ON steuer(steuerkonto_id);
@@ -253,3 +263,6 @@ ALTER TABLE geschaeftsjahr ADD CONSTRAINT fk_gj_self FOREIGN KEY (vorjahr_id) RE
 
 ALTER TABLE abschreibung ADD CONSTRAINT fk_abschreibung_av FOREIGN KEY (av_id) REFERENCES anlagevermoegen (id);
 ALTER TABLE abschreibung ADD CONSTRAINT fk_abschreibung_buchung FOREIGN KEY (buchung_id) REFERENCES buchung (id);
+
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_konto FOREIGN KEY (konto_id) REFERENCES konto (id);
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_mandant FOREIGN KEY (mandant_id) REFERENCES mandant (id);

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -277,4 +277,4 @@ INSERT INTO konto (id, kontoart_id, kontonummer, name, kontenrahmen_id, steuer_i
 INSERT INTO konto (id, kontoart_id, kontonummer, name, kontenrahmen_id, steuer_id) VALUES (1210, 1, '7100', 'Zinserträge', 2, 1007);
 INSERT INTO konto (id, kontoart_id, kontonummer, name, kontenrahmen_id, steuer_id) VALUES (1211, 1, '4337', 'Erlöse aus Leistungen §13b', 2, 1010);
 
-INSERT INTO version (name,version) values ('db',10);
+INSERT INTO version (name,version) values ('db',11);

--- a/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListMenu.java
+++ b/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListMenu.java
@@ -27,6 +27,7 @@ import de.willuhn.jameica.fibu.gui.action.BuchungNeu;
 import de.willuhn.jameica.fibu.rmi.Buchung;
 import de.willuhn.jameica.fibu.rmi.Geschaeftsjahr;
 import de.willuhn.jameica.fibu.rmi.Konto;
+import de.willuhn.jameica.fibu.rmi.Kontoart;
 import de.willuhn.jameica.fibu.rmi.Mandant;
 import de.willuhn.jameica.fibu.server.Math;
 import de.willuhn.jameica.gui.Action;
@@ -273,12 +274,53 @@ public class UmsatzListMenu implements Extension
       Konto haben = template.getHabenKonto();
       if (auto && haben == null)
         throw new ApplicationException(i18n.tr("Buchungsvorlage \"{0}\" enthält kein Haben-Konto",template.getName()));
+      
+      //Bei Storno-Buchungen drehen wir soll und haben um
+      //Wenn beides vom typ Bankkonto ist (zb. bei Verbindlichkeitskonten) Konto mit name "Bank" als Bankkonto verwenden
+      if((u.getBetrag() > 0.1d && haben.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (soll.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || haben.getName().equals("Bank")))
+    		  || (u.getBetrag() < -0.1d && soll.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (haben.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || soll.getName().equals("Bank")))) {
+    	soll = template.getHabenKonto();
+    	haben = template.getSollKonto();
+      }
+      
+      //Bankkonten durch die richtigen Konten ersetzen
+      if(soll.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (haben.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || soll.getName().compareTo("Bank") == 0))
+      {
+    	  de.willuhn.jameica.fibu.rmi.Kontozuordnung zuordnung = null;
+   	      // Vorlage suchen
+   	      DBIterator i = Settings.getDBService().createList(de.willuhn.jameica.fibu.rmi.Kontozuordnung.class);
+   	      i.addFilter("hb_konto_id = ?",u.getKonto().getID());
+   	      i.addFilter("mandant_id = ?",template.getMandant().getID());
+   	      if (i.hasNext())
+   	      {
+   	    	zuordnung = (de.willuhn.jameica.fibu.rmi.Kontozuordnung) i.next();
+   	    	buchung.setSollKonto(zuordnung.getKonto());
+   	      }
+   	      
+      }
+     
+      if(haben.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (soll.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || haben.getName().compareTo("Bank") == 0))
+      {
+    	  de.willuhn.jameica.fibu.rmi.Kontozuordnung zuordnung = null;
+   	      // Vorlage suchen
+   	      DBIterator i = Settings.getDBService().createList(de.willuhn.jameica.fibu.rmi.Kontozuordnung.class);
+   	      i.addFilter("hb_konto_id = ?",u.getKonto().getID());
+   	      i.addFilter("mandant_id = ?",template.getMandant().getID());
+   	      if (i.hasNext())
+   	      {
+   	    	zuordnung = (de.willuhn.jameica.fibu.rmi.Kontozuordnung) i.next();
+   	    	buchung.setHabenKonto(zuordnung.getKonto());
+   	      }
+   	      
+      }
 
       buchung.setBruttoBetrag(template.getBetrag());
       buchung.setBetrag(new Math().netto(template.getBetrag(),template.getSteuer()));
       buchung.setDatum(new Date());
-      buchung.setSollKonto(soll);
-      buchung.setHabenKonto(haben);
+      if(buchung.getSollKonto() == null)
+    	  buchung.setSollKonto(soll);
+      if(buchung.getHabenKonto() == null)
+    	  buchung.setHabenKonto(haben);
       buchung.setSteuer(template.getSteuer());
       buchung.setText(StringUtils.trimToEmpty(template.getText()));
     }

--- a/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListMenu.java
+++ b/src/de/willuhn/jameica/fibu/ext/hibiscus/UmsatzListMenu.java
@@ -277,8 +277,8 @@ public class UmsatzListMenu implements Extension
       
       //Bei Storno-Buchungen drehen wir soll und haben um
       //Wenn beides vom typ Bankkonto ist (zb. bei Verbindlichkeitskonten) Konto mit name "Bank" als Bankkonto verwenden
-      if((u.getBetrag() > 0.1d && haben.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (soll.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || haben.getName().equals("Bank")))
-    		  || (u.getBetrag() < -0.1d && soll.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (haben.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || soll.getName().equals("Bank")))) {
+      if((u.getBetrag() >= 0.01d && haben.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (soll.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || haben.getName().equals("Bank")))
+    		  || (u.getBetrag() <= -0.01d && soll.getKontoArt().getKontoArt() == Kontoart.KONTOART_GELD && (haben.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD || soll.getName().equals("Bank")))) {
     	soll = template.getHabenKonto();
     	haben = template.getSollKonto();
       }

--- a/src/de/willuhn/jameica/fibu/gui/action/KontozuordnungNeu.java
+++ b/src/de/willuhn/jameica/fibu/gui/action/KontozuordnungNeu.java
@@ -1,0 +1,18 @@
+package de.willuhn.jameica.fibu.gui.action;
+
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Action zum Anlegen einer neuen Kontozuordnung.
+ */
+public class KontozuordnungNeu implements Action{
+	/**
+	   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+	   */
+	  public void handleAction(Object context) throws ApplicationException
+	  {
+	    GUI.startView(de.willuhn.jameica.fibu.gui.views.KontozuordnungNeu.class,context);
+	  }
+}

--- a/src/de/willuhn/jameica/fibu/gui/controller/KontozuordnungControl.java
+++ b/src/de/willuhn/jameica/fibu/gui/controller/KontozuordnungControl.java
@@ -1,0 +1,146 @@
+package de.willuhn.jameica.fibu.gui.controller;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.jameica.fibu.Fibu;
+import de.willuhn.jameica.fibu.Settings;
+import de.willuhn.jameica.fibu.gui.input.KontoInput;
+import de.willuhn.jameica.fibu.rmi.Kontozuordnung;
+import de.willuhn.jameica.fibu.rmi.Mandant;
+import de.willuhn.jameica.fibu.rmi.Geschaeftsjahr;
+import de.willuhn.jameica.fibu.rmi.Konto;
+import de.willuhn.jameica.fibu.rmi.Kontoart;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+public class KontozuordnungControl  extends AbstractControl
+{
+	  private final static I18N i18n = Application.getPluginLoader().getPlugin(Fibu.class).getResources().getI18N();
+
+		private Kontozuordnung buchung 		= null;
+
+	  private Input bezeichnung             = null;
+	  private KontoInput kontoAuswahl   = null;
+	  private de.willuhn.jameica.hbci.gui.input.KontoInput HbKontoAuswahl   = null;
+	  
+	  /**
+	   * @param view
+	   */
+	  public KontozuordnungControl(AbstractView view)
+	  {
+	    super(view);
+	  }
+
+		/**
+		 * Liefert die Buchung.
+	   * @return die Buchung.
+	   * @throws RemoteException
+	   */
+	  public Kontozuordnung getBuchung() throws RemoteException
+		{
+			if (this.buchung != null)
+				return this.buchung;
+			
+			if(getCurrentObject() instanceof Kontozuordnung)
+				this.buchung = (Kontozuordnung) getCurrentObject();
+			
+			if (this.buchung != null)
+				return this.buchung;
+			
+			this.buchung = (Kontozuordnung) Settings.getDBService().createObject(Kontozuordnung.class,null);
+	    
+	    // Den Parameter geben wir automatisch vor.
+		if(getCurrentObject() instanceof Mandant)
+			this.buchung.setMandant((Mandant) getCurrentObject());
+
+		return this.buchung;
+		}
+
+	  /**
+		 * Liefert das Eingabe-Feld zur Auswahl des SollKontos.
+	   * @return Eingabe-Feld.
+	   * @throws RemoteException
+	   */
+	  public KontoInput getKontoAuswahl() throws RemoteException
+		{
+			if (this.kontoAuswahl != null)
+				return this.kontoAuswahl;
+
+	    Geschaeftsjahr jahr = Settings.getActiveGeschaeftsjahr();
+	    this.kontoAuswahl = new KontoInput(jahr.getKontenrahmen().getKonten(), getBuchung().getKonto());
+	    this.kontoAuswahl.setName(i18n.tr("Konto"));
+	    return this.kontoAuswahl;
+	  }
+	  
+	  /**
+		 * Liefert das Eingabe-Feld zur Auswahl des HbKontos.
+	   * @return Eingabe-Feld.
+	   * @throws RemoteException
+	   */
+	  public de.willuhn.jameica.hbci.gui.input.KontoInput getHbKontoAuswahl() throws RemoteException
+		{
+			if (this.HbKontoAuswahl != null)
+				return this.HbKontoAuswahl;
+
+	    this.HbKontoAuswahl = new de.willuhn.jameica.hbci.gui.input.KontoInput((de.willuhn.jameica.hbci.rmi.Konto)getBuchung().getHbKonto(), null);
+	    this.HbKontoAuswahl.setName(i18n.tr("Konto"));
+	    return this.HbKontoAuswahl;
+	  }
+
+	  /**
+	   * Liefert das Eingabe-Feld fuer die Bezeichnung der Vorlage.
+	   * @return Eingabe-Feld.
+	   * @throws RemoteException
+	   */
+	  public Input getBezeichnung() throws RemoteException
+	  {
+	    if (this.bezeichnung != null)
+	      return this.bezeichnung;
+	    
+	    this.bezeichnung = new TextInput(getBuchung().getName());
+	    this.bezeichnung.setName(i18n.tr("Bezeichnung der Zuordnung"));
+	    this.bezeichnung.setMandatory(true);
+	    return this.bezeichnung;
+	  }
+	  	  
+	  /**
+	   * Speichert die Buchung.
+	   * @param startNew legt fest, ob danach sofort der Dialog zum Erfassen einer neuen Buchung geoeffnet werden soll.
+	   */
+	  public void handleStore(boolean startNew)
+	  {
+	    try {
+    	Konto k = (Konto) getKontoAuswahl().getValue();
+        if(k.getKontoArt().getKontoArt() != Kontoart.KONTOART_GELD && k.getKontoArt().getKontoArt() != Kontoart.KONTOART_PRIVAT) {
+        	GUI.getView().setErrorText(i18n.tr("Das Konto muss ein Geldkonto sein!"));
+	        return;
+        }
+	      getBuchung().setKonto((Konto) getKontoAuswahl().getValue());
+	      getBuchung().setName((String)getBezeichnung().getValue());
+	      getBuchung().setHbKonto((de.willuhn.jameica.hbci.rmi.Konto)getHbKontoAuswahl().getValue());
+	      
+	      // und jetzt speichern wir.
+				getBuchung().store();
+				Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Kontozuordnung gespeichert"),StatusBarMessage.TYPE_SUCCESS));
+	    }
+	    catch (ApplicationException ae)
+	    {
+	      Application.getMessagingFactory().sendMessage(new StatusBarMessage(ae.getMessage(),StatusBarMessage.TYPE_ERROR));
+	    }
+	    catch (Exception e)
+	    {
+	      if (!(e instanceof ApplicationException))
+				  Logger.error("unable to store kontozuordnung",e);
+	      Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Fehler beim Speichern der Kontozuordnung."),StatusBarMessage.TYPE_ERROR));
+	    }
+	    
+	  }
+	}

--- a/src/de/willuhn/jameica/fibu/gui/menus/KontozuordnungListMenu.java
+++ b/src/de/willuhn/jameica/fibu/gui/menus/KontozuordnungListMenu.java
@@ -1,0 +1,58 @@
+package de.willuhn.jameica.fibu.gui.menus;
+
+import de.willuhn.jameica.fibu.Fibu;
+import de.willuhn.jameica.fibu.gui.action.KontozuordnungNeu;
+import de.willuhn.jameica.fibu.gui.action.DBObjectDelete;
+import de.willuhn.jameica.fibu.rmi.Mandant;
+import de.willuhn.jameica.gui.parts.ContextMenu;
+import de.willuhn.jameica.gui.parts.ContextMenuItem;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+/**
+ * Vorkonfiguriertes Kontext-Menu fuer Listen von Kontozuordnungen.
+ */
+public class KontozuordnungListMenu extends ContextMenu
+{
+	  private final static I18N i18n = Application.getPluginLoader().getPlugin(Fibu.class).getResources().getI18N();
+	  
+	  /**
+	   * ct.
+	   * @param mandant der Mandant.
+	   */
+	  public KontozuordnungListMenu(Mandant mandant)
+	  {
+	    this.addItem(new GJCheckedSingleContextMenuItem(i18n.tr("Öffnen"), new KontozuordnungNeu(),"document-open.png"));
+	    this.addItem(new GJContextMenuItem(i18n.tr("Neue Kontozuordnung..."), new BNeu(mandant),"list-add.png"));
+	    this.addItem(new GJCheckedContextMenuItem(i18n.tr("Löschen..."), new DBObjectDelete(),"user-trash-full.png"));
+	    this.addItem(ContextMenuItem.SEPARATOR);
+	    //this.addItem(new CheckedContextMenuItem(i18n.tr("Exportieren..."),new BuchungstemplateExport(),"document-save.png"));
+	    //this.addItem(new ContextMenuItem(i18n.tr("Importieren..."),new BuchungstemplateImport(),"document-open.png"));
+	  }
+	  
+	  /**
+	   * Erzeugt immer eine neue Vorlage - unabhaengig vom Kontext.
+	   */
+	  private class BNeu extends KontozuordnungNeu
+	  {
+	    private Mandant mandant = null;
+
+	    /**
+	     * ct.
+	     * @param mandant der Mandant.
+	     */
+	    private BNeu(Mandant mandant)
+	    {
+	      this.mandant = mandant;
+	    }
+
+	    /**
+	     * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+	     */
+	    public void handleAction(Object context) throws ApplicationException
+	    {
+	      super.handleAction(this.mandant);
+	    }
+	  }
+	}

--- a/src/de/willuhn/jameica/fibu/gui/part/KontoZuordnungList.java
+++ b/src/de/willuhn/jameica/fibu/gui/part/KontoZuordnungList.java
@@ -1,0 +1,178 @@
+package de.willuhn.jameica.fibu.gui.part;
+
+import java.rmi.RemoteException;
+
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.fibu.Fibu;
+import de.willuhn.jameica.fibu.Settings;
+import de.willuhn.jameica.fibu.gui.menus.KontozuordnungListMenu;
+import de.willuhn.jameica.fibu.messaging.ObjectImportedMessage;
+import de.willuhn.jameica.fibu.rmi.Geschaeftsjahr;
+import de.willuhn.jameica.fibu.rmi.Konto;
+import de.willuhn.jameica.fibu.rmi.Mandant;
+import de.willuhn.jameica.fibu.rmi.Kontozuordnung;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.formatter.Formatter;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.util.DelayedListener;
+import de.willuhn.jameica.messaging.Message;
+import de.willuhn.jameica.messaging.MessageConsumer;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.I18N;
+
+public class KontoZuordnungList extends TablePart {
+	private final static I18N i18n = Application.getPluginLoader().getPlugin(Fibu.class).getResources().getI18N();
+	  
+	  private MessageConsumer mc = new MyMessageConsumer();
+
+	  /**
+	   * ct.
+	   * @param mandant der Mandant.
+	   * @param list Liste der Knto-Zuordnungen.
+	   * @param action
+	   */
+	  public KontoZuordnungList(Mandant mandant, GenericIterator list, Action action)
+	  {
+	    super(list, action);
+	    addColumn(i18n.tr("Bezeichnung"),"name");
+	    addColumn(i18n.tr("Hibscus Konto"),"hb_konto_id",new Formatter() {
+	      public String format(Object o)
+	      {
+	        if (o == null)
+	          return null;
+	        try
+	        {
+	          de.willuhn.jameica.hbci.rmi.Konto k =  (de.willuhn.jameica.hbci.rmi.Konto) de.willuhn.jameica.hbci.Settings.getDBService().createObject(de.willuhn.jameica.hbci.rmi.Konto.class,o.toString());
+	        	
+	          //de.willuhn.jameica.hbci.rmi.Konto k = (de.willuhn.jameica.hbci.rmi.Konto) o;
+	          return k.getBezeichnung() + " [" + k.getKontonummer() + "]";
+	        }
+	        catch (RemoteException e)
+	        {
+	          Logger.error("unable to read hb-konto",e);
+	          return "nicht ermittelbar";
+	        }
+	      }});
+	    addColumn(i18n.tr("Konto"),"konto_id", new Formatter() {
+	      public String format(Object o)
+	      {
+	        if (o == null || !(o instanceof Konto))
+	          return null;
+	        try
+	        {
+	          Konto k = (Konto) o;
+	          return k.getKontenrahmen().getName() + " - " + k.getKontonummer() + " [" + k.getName() + "]";
+	        }
+	        catch (RemoteException e)
+	        {
+	          Logger.error("unable to read konto",e);
+	          return "nicht ermittelbar";
+	        }
+	      }
+	    });
+	    setContextMenu(new KontozuordnungListMenu(mandant));
+	    setRememberColWidths(true);
+	    setRememberOrder(true);
+	    setMulti(true);
+	  }
+	  
+	  /**
+	   * Initialisiert die Liste der Kontozuordnungen.
+	   * @return Liste der Kontozuordnungen.
+	   * @throws RemoteException
+	   */
+	  private static GenericIterator init() throws RemoteException
+	  {
+	    Geschaeftsjahr jahr = Settings.getActiveGeschaeftsjahr();
+	    DBIterator list = Settings.getDBService().createList(Kontozuordnung.class);
+	    list.addFilter("(mandant_id is null or mandant_id = " + jahr.getMandant().getID() + ")");
+	    list.setOrder("order by name");
+	    return list;
+	  }
+
+	  /**
+	   * @see de.willuhn.jameica.gui.parts.TablePart#paint(org.eclipse.swt.widgets.Composite)
+	   */
+	  public synchronized void paint(Composite parent) throws RemoteException
+	  {
+	    super.paint(parent);
+	    Application.getMessagingFactory().registerMessageConsumer(this.mc);
+
+	    parent.addDisposeListener(new DisposeListener() {
+	      public void widgetDisposed(DisposeEvent e)
+	      {
+	        Application.getMessagingFactory().unRegisterMessageConsumer(mc);
+	      }
+	    });
+	  }
+
+	  /**
+	   * Listener, der das Neuladen der Kontozuordnungen uebernimmt.
+	   */
+	  private class MyListener implements Listener
+	  {
+	    /**
+	     * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
+	     */
+	    public void handleEvent(Event event)
+	    {
+	      try
+	      {
+	        removeAll();
+	        GenericIterator list = init();
+	        while (list.hasNext())
+	          addItem(list.next());
+	        
+	        // Sortierung wiederherstellen
+	        sort();
+	      }
+	      catch (RemoteException re)
+	      {
+	        Logger.error("unable to reload data",re);
+	        Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Fehler beim Aktualisieren der Buchungsvorlagen: {0}",re.getMessage()),StatusBarMessage.TYPE_ERROR));
+	      }
+	    }
+	    
+	  }
+	  
+	  /**
+	   * Mit dem Consumer werden wir ueber importierte Datensaetze informiert.
+	   */
+	  private class MyMessageConsumer implements MessageConsumer
+	  {
+	    private DelayedListener delay = new DelayedListener(new MyListener());
+	    
+	    /**
+	     * @see de.willuhn.jameica.messaging.MessageConsumer#autoRegister()
+	     */
+	    public boolean autoRegister()
+	    {
+	      return false;
+	    }
+
+	    /**
+	     * @see de.willuhn.jameica.messaging.MessageConsumer#getExpectedMessageTypes()
+	     */
+	    public Class[] getExpectedMessageTypes()
+	    {
+	      return new Class[]{ObjectImportedMessage.class};
+	    }
+
+	    /**
+	     * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
+	     */
+	    public void handleMessage(Message message) throws Exception
+	    {
+	      delay.handleEvent(null);
+	    }
+	  }
+}

--- a/src/de/willuhn/jameica/fibu/gui/views/KontozuordnungNeu.java
+++ b/src/de/willuhn/jameica/fibu/gui/views/KontozuordnungNeu.java
@@ -1,0 +1,92 @@
+package de.willuhn.jameica.fibu.gui.views;
+
+import de.willuhn.jameica.fibu.Fibu;
+import de.willuhn.jameica.fibu.gui.action.DBObjectDelete;
+import de.willuhn.jameica.fibu.gui.controller.KontozuordnungControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.extension.Extendable;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.Container;
+import de.willuhn.jameica.gui.util.SimpleContainer;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+/**
+ * Erzeugt eine neue Buchung oder bearbeitet eine existierende.
+ * @author henken
+ */
+public class KontozuordnungNeu extends AbstractView implements Extendable
+{
+	  private final static I18N i18n = Application.getPluginLoader().getPlugin(Fibu.class).getResources().getI18N();
+
+	  private Container container             = null;
+	  private KontozuordnungControl control = null;
+
+	  /**
+	   * @see de.willuhn.jameica.gui.AbstractView#bind()
+	   */
+	  public void bind() throws Exception
+	  {
+			GUI.getView().setTitle(i18n.tr("Kontozuordnung bearbeiten"));
+
+	    this.control   = new KontozuordnungControl(this);
+	    
+	    this.container = new SimpleContainer(getParent());
+	    this.container.addHeadline(i18n.tr("Eigenschaften"));
+	    this.container.addInput(control.getBezeichnung());
+	    this.container.addInput(control.getKontoAuswahl());
+	    this.container.addInput(control.getHbKontoAuswahl());
+
+	    ButtonArea buttonArea = new ButtonArea();
+	    buttonArea.addButton(i18n.tr("Löschen"), new DBObjectDelete(), getCurrentObject(),false,"user-trash-full.png");
+	    buttonArea.addButton(new Button(i18n.tr("Speichern"),new Action() {
+	      public void handleAction(Object context) throws ApplicationException
+	      {
+	        control.handleStore(false);
+	      }
+	    },null,true,"document-save.png"));
+	    buttonArea.paint(getParent());
+	  }
+
+	  
+	  /**
+	   * @see de.willuhn.jameica.gui.AbstractView#unbind()
+	   */
+	  public void unbind() throws ApplicationException
+	  {
+	    this.container = null;
+	    this.control   = null;
+	  }
+
+
+	  /**
+	   * @see de.willuhn.jameica.gui.extension.Extendable#getExtendableID()
+	   */
+	  public String getExtendableID()
+	  {
+	    return this.getClass().getName();
+	  }
+	  
+	  /**
+	   * Liefert den Container, in dem sich die Controls befinden.
+	   * @return der Container mit den Controls.
+	   */
+	  public Container getContainer()
+	  {
+	    return this.container;
+	  }
+	  
+	  /**
+	   * Liefert den Controller.
+	   * @return der Controller.
+	   */
+	  public KontozuordnungControl getControl()
+	  {
+	    return this.control;
+	  }
+	  
+	}

--- a/src/de/willuhn/jameica/fibu/gui/views/MandantNeu.java
+++ b/src/de/willuhn/jameica/fibu/gui/views/MandantNeu.java
@@ -21,12 +21,14 @@ import de.willuhn.jameica.fibu.gui.action.BuchungstemplateNeu;
 import de.willuhn.jameica.fibu.gui.action.GeschaeftsjahrClose;
 import de.willuhn.jameica.fibu.gui.action.GeschaeftsjahrNeu;
 import de.willuhn.jameica.fibu.gui.action.KontoNeu;
+import de.willuhn.jameica.fibu.gui.action.KontozuordnungNeu;
 import de.willuhn.jameica.fibu.gui.action.MandantDelete;
 import de.willuhn.jameica.fibu.gui.action.SteuerNeu;
 import de.willuhn.jameica.fibu.gui.controller.MandantControl;
 import de.willuhn.jameica.fibu.gui.part.BuchungstemplateList;
 import de.willuhn.jameica.fibu.gui.part.GeschaeftsjahrList;
 import de.willuhn.jameica.fibu.gui.part.KontoList;
+import de.willuhn.jameica.fibu.gui.part.KontoZuordnungList;
 import de.willuhn.jameica.fibu.gui.part.SteuerList;
 import de.willuhn.jameica.fibu.rmi.Buchungstemplate;
 import de.willuhn.jameica.fibu.rmi.Geschaeftsjahr;
@@ -154,11 +156,22 @@ public class MandantNeu extends AbstractView
     vorlagenList.setOrder("order by name");
     TablePart t4 = new BuchungstemplateList(mandant, vorlagenList, new BuchungstemplateNeu());
     t4.paint(vorlagen.getComposite());
+    
+    if (Application.getPluginLoader()
+        .getPlugin("de.willuhn.jameica.hbci.HBCI") != null)
+    {
+	    TabGroup kontenZuordnungen = new TabGroup(this.tabs,i18n.tr("Zuordnung Bankkonten"));
+	    DBIterator kontoZuordnungList = Settings.getDBService().createList(de.willuhn.jameica.fibu.rmi.Kontozuordnung.class);
+	    kontoZuordnungList.addFilter("mandant_id = " + mandant.getID());
+	    kontoZuordnungList.setOrder("order by name");
+	    TablePart t5 = new KontoZuordnungList(mandant, kontoZuordnungList, new KontozuordnungNeu());
+	    t5.paint(kontenZuordnungen.getComposite());
+    }
 
     if (activeTab != null)
       this.tabs.setSelection(activeTab);
   }
-
+  
   /**
    * @see de.willuhn.jameica.gui.AbstractView#unbind()
    */

--- a/src/de/willuhn/jameica/fibu/rmi/Kontozuordnung.java
+++ b/src/de/willuhn/jameica/fibu/rmi/Kontozuordnung.java
@@ -1,0 +1,66 @@
+package de.willuhn.jameica.fibu.rmi;
+
+import java.rmi.RemoteException;
+
+/*
+ * Zuordnung der Hibiscus Konten zu Syntax Konten.
+ * Bei der Verwendung von Buchungstemplates wird 
+ * die Buchung dem Richtigen Geldkonto zugeordnet
+ */
+public interface Kontozuordnung extends Transfer{
+	 /**
+	   * Liefert einen sprechenden Namen fuer die Kontozuordnung.
+	   * @return Name.
+	   * @throws RemoteException
+	   */
+	  public String getName() throws RemoteException;
+	  
+	  /**
+	   * Setzt den sprechenden Namen fuer die Kontozuordnung.
+	   * @param Name.
+	   * @throws RemoteException
+	   */
+	  public void setName(String name) throws RemoteException;
+
+	  /**
+	   * Liefert das Konto.
+	   * @return Konto.
+	   * @throws RemoteException
+	   */
+	  public Konto getKonto() throws RemoteException;
+	  
+	  /**
+	   * Setzt den Mandanten.
+	   * @param Mandant.
+	   * @throws RemoteException
+	   */
+	  public void setKonto(Konto name) throws RemoteException;
+	  
+	  /**
+	   * Liefert den Mandanten.
+	   * @return Mandant.
+	   * @throws RemoteException
+	   */
+	  public Mandant getMandant() throws RemoteException;
+	  
+	  /**
+	   * Setzt den Mandanten.
+	   * @param Mandant.
+	   * @throws RemoteException
+	   */
+	  public void setMandant(Mandant mandant) throws RemoteException;
+	  
+	  /**
+	   * Liefert das Hibiscus Konto.
+	   * @return Konto.
+	   * @throws RemoteException
+	   */
+	  public de.willuhn.jameica.hbci.rmi.Konto getHbKonto() throws RemoteException;
+	  
+	  /**
+	   * Setzt dase Hibiscus Konto.
+	   * @param Konto.
+	   * @throws RemoteException
+	   */
+	  public void setHbKonto(de.willuhn.jameica.hbci.rmi.Konto hbKonto_id) throws RemoteException;
+}

--- a/src/de/willuhn/jameica/fibu/server/KontozuordnungImpl.java
+++ b/src/de/willuhn/jameica/fibu/server/KontozuordnungImpl.java
@@ -1,0 +1,155 @@
+package de.willuhn.jameica.fibu.server;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.fibu.rmi.Konto;
+import de.willuhn.jameica.fibu.rmi.Kontozuordnung;
+import de.willuhn.jameica.fibu.rmi.Mandant;
+import de.willuhn.jameica.hbci.Settings;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class KontozuordnungImpl extends AbstractTransferImpl implements Kontozuordnung {
+
+	/**
+	 * Erzeugt eine neue Kontozuordnung
+	 */
+	public KontozuordnungImpl() throws RemoteException{
+		super();
+	}
+	
+	/**
+	   * @see de.willuhn.datasource.db.AbstractDBObject#getTableName()
+	   */
+	  protected String getTableName()
+	  {
+	    return "kontozuordnung";
+	  }
+
+	  /**
+	   * @see de.willuhn.datasource.GenericObject#getPrimaryAttribute()
+	   */
+	  public String getPrimaryAttribute() throws RemoteException
+	  {
+	    return "name";
+	  }
+	  
+	  /**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#getName()
+	   */
+	public String getName() throws RemoteException {
+		return (String) getAttribute("name");
+	}
+	
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#setName()
+	   */
+	public void setName(String name) throws RemoteException {
+		 setAttribute("name",name);
+
+	}
+	
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#getKonto()
+	   */
+	public Konto getKonto() throws RemoteException {
+		return (Konto) getAttribute("konto_id");
+	}
+	
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#setKonto()
+	   */
+	public void setKonto(Konto konto) throws RemoteException {
+		  setAttribute("konto_id",konto);
+
+	}
+	
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#getMandant()
+	   */
+	public Mandant getMandant() throws RemoteException{
+		return (Mandant) getAttribute("mandant_id");
+	}
+	
+	
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#setMandant()
+	   */
+	public void setMandant(Mandant mandant) throws RemoteException {
+		setAttribute("mandant_id",mandant);
+
+	}
+
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#getHbKonto()
+	   */
+	public de.willuhn.jameica.hbci.rmi.Konto getHbKonto() throws RemoteException {
+		String s =null;
+		if(getAttribute("hb_konto_id") != null)
+			s = (String) getAttribute("hb_konto_id").toString();
+		return (de.willuhn.jameica.hbci.rmi.Konto) Settings.getDBService().createObject(de.willuhn.jameica.hbci.rmi.Konto.class,s);
+	}
+
+	/**
+	   * @see de.willuhn.jameica.fibu.rmi.Kontozuordnung#setHbKonto()
+	   */
+	public void setHbKonto(de.willuhn.jameica.hbci.rmi.Konto hbKonto_id) throws RemoteException {
+		setAttribute("hb_konto_id",hbKonto_id.getID());
+	}
+	
+	/**
+	   * @see de.willuhn.datasource.db.AbstractDBObject#insertCheck()
+	   */
+	  protected void insertCheck() throws ApplicationException
+	  {
+	    try
+	    {
+	      if (getName() == null || getName().length() == 0)
+	        throw new ApplicationException(i18n.tr("Bitten geben Sie eine Bezeichnung an."));
+	      
+	      // Falls eine Konto-Kategorie zugeordnet ist, checken wir, ob
+	      // nicht schon eine andere Vorlage dieser zugeordnet ist.
+	      if (this.getHbKonto() != null && this.getHbKonto() instanceof de.willuhn.jameica.hbci.rmi.Konto)
+	      {
+	        DBIterator list = this.getService().createList(Kontozuordnung.class);
+	        list.addFilter("hb_konto_id = ?",this.getHbKonto().getID());
+	        list.addFilter("mandant_id = ?",this.getMandant().getID());
+	        if (!this.isNewObject())
+	          list.addFilter("id != " + this.getID()); // Natuerlich duerfen wir uns selbst nicht finden ;)
+	        if (list.hasNext())
+	        {
+	          Kontozuordnung t = (Kontozuordnung) list.next();
+	          throw new ApplicationException(i18n.tr("Dem Hibiscus Konto ist bereits die Vorlage \"{0}\" zugeordnet",t.getName()));
+	        }
+	      }
+	    }
+	    catch (RemoteException e)
+	    {
+	      Logger.error("unable to check template",e);
+	      throw new ApplicationException(i18n.tr("Fehler beim Prüfen der Vorlage"));
+	    }
+	    super.insertCheck();
+	  }
+	  
+	  /**
+	   * @see de.willuhn.datasource.db.AbstractDBObject#updateCheck()
+	   */
+	  protected void updateCheck() throws ApplicationException
+	  {
+	    insertCheck();
+	  }
+	  
+	/**
+	   * @see de.willuhn.jameica.fibu.server.AbstractUserObjectImpl#getForeignObject(java.lang.String)
+	   */
+	  protected Class getForeignObject(String field) throws RemoteException
+	  {
+	    if ("mandant_id".equals(field))
+	      return Mandant.class;
+	    if ("konto_id".equals(field))
+	      return Konto.class;
+	    return super.getForeignObject(field);
+	  }
+
+}

--- a/updates/htwo-update0011.sql
+++ b/updates/htwo-update0011.sql
@@ -1,0 +1,14 @@
+CREATE TABLE kontozuordnung (
+  id IDENTITY(1),
+  name varchar(255) NOT NULL,
+  mandant_id int(10) NOT NULL,
+  konto_id int(10) NOT NULL,
+  hb_konto_id int(10) NOT NULL,
+  UNIQUE (id),
+  PRIMARY KEY (id)
+);
+
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_konto FOREIGN KEY (konto_id) REFERENCES konto (id) DEFERRABLE;
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_mandant FOREIGN KEY (mandant_id) REFERENCES mandant (id) DEFERRABLE;
+
+COMMIT;

--- a/updates/mckoi-update0011.sql
+++ b/updates/mckoi-update0011.sql
@@ -1,0 +1,14 @@
+CREATE TABLE kontozuordnung (
+  id NUMERIC default UNIQUEKEY('kontozuordnung'),
+  name varchar(255) NOT NULL,
+  mandant_id int(10) NOT NULL,
+  konto_id int(10) NOT NULL,
+  hb_konto_id int(10) NOT NULL,
+  UNIQUE (id), 
+  PRIMARY KEY (id)
+);
+
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_konto FOREIGN KEY (konto_id) REFERENCES konto (id) DEFERRABLE;
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_mandant FOREIGN KEY (mandant_id) REFERENCES mandant (id) DEFERRABLE;
+
+COMMIT;

--- a/updates/mysql-update0011.sql
+++ b/updates/mysql-update0011.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS kontozuordnung (
+  id int(10) NOT NULL AUTO_INCREMENT,
+  name varchar(255) NOT NULL,
+  mandant_id int(10) NOT NULL,
+  konto_id int(10) NOT NULL,
+  hb_konto_id int(10) NOT NULL,
+  UNIQUE (id),
+  PRIMARY KEY (id)
+) ENGINE = InnoDB;
+
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_konto FOREIGN KEY (konto_id) REFERENCES konto (id);
+ALTER TABLE kontozuordnung ADD CONSTRAINT FK_kontozuordnung_mandant FOREIGN KEY (mandant_id) REFERENCES mandant (id);
+
+COMMIT;


### PR DESCRIPTION
Hier habe ich noch einen Patch den ich vor längerer Zeit mal erstellt habe. Es können die Hibiscus-Konten Syntax-Bankkonten zugeordnet werden, so dass bei der Buchungsübernahme automatisch auf das richtige Konto gebucht wird. Macht bei mehreren Bankkonten und vielen Buchungen durchaus sinn.