### PR TITLE
Noch zu Kontozuordnung

### DIFF
--- a/src/de/willuhn/jameica/fibu/gui/controller/KontozuordnungControl.java
+++ b/src/de/willuhn/jameica/fibu/gui/controller/KontozuordnungControl.java
@@ -4,6 +4,7 @@ import java.rmi.RemoteException;
 
 import org.apache.commons.lang.StringUtils;
 
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.fibu.Fibu;
 import de.willuhn.jameica.fibu.Settings;
 import de.willuhn.jameica.fibu.gui.input.KontoInput;
@@ -77,9 +78,10 @@ public class KontozuordnungControl extends AbstractControl
 		{
 			if (this.kontoAuswahl != null)
 				return this.kontoAuswahl;
-
 	    Geschaeftsjahr jahr = Settings.getActiveGeschaeftsjahr();
-	    this.kontoAuswahl = new KontoInput(jahr.getKontenrahmen().getKonten(), getBuchung().getKonto());
+	    DBIterator list = jahr.getKontenrahmen().getKonten();
+	    list.addFilter("(kontoart_id = " + Kontoart.KONTOART_GELD +" OR kontoart_id = " + Kontoart.KONTOART_PRIVAT+")");
+	    this.kontoAuswahl = new KontoInput(list, getBuchung().getKonto());
 	    this.kontoAuswahl.setName(i18n.tr("SynTAX-Geldkonto"));
 	    return this.kontoAuswahl;
 	  }

--- a/src/de/willuhn/jameica/fibu/migration/AbstractDatabaseMigrationTask.java
+++ b/src/de/willuhn/jameica/fibu/migration/AbstractDatabaseMigrationTask.java
@@ -20,6 +20,7 @@ import de.willuhn.jameica.fibu.rmi.Kontenrahmen;
 import de.willuhn.jameica.fibu.rmi.Konto;
 import de.willuhn.jameica.fibu.rmi.Kontoart;
 import de.willuhn.jameica.fibu.rmi.Kontotyp;
+import de.willuhn.jameica.fibu.rmi.Kontozuordnung;
 import de.willuhn.jameica.fibu.rmi.Mandant;
 import de.willuhn.jameica.fibu.rmi.Steuer;
 import de.willuhn.jameica.fibu.rmi.Version;
@@ -97,6 +98,7 @@ public abstract class AbstractDatabaseMigrationTask implements BackgroundTask
       failCount += copy(source,target,monitor,Anfangsbestand.class);
       failCount += copy(source,target,monitor,Abschreibung.class);
       failCount += copy(source,target,monitor,Version.class);
+      failCount += copy(source,target,monitor,Kontozuordnung.class);
       Logger.info("finished data migration");
       Logger.info("################################################");
  

--- a/src/de/willuhn/jameica/fibu/server/KontozuordnungImpl.java
+++ b/src/de/willuhn/jameica/fibu/server/KontozuordnungImpl.java
@@ -122,8 +122,8 @@ public class KontozuordnungImpl extends AbstractTransferImpl implements Kontozuo
       if (this.getHbKonto() != null)
       {
         DBIterator list = this.getService().createList(Kontozuordnung.class);
-        list.addFilter("hb_konto_id = ?", this.getHbKonto().getID());
-        list.addFilter("mandant_id = ?", this.getMandant().getID());
+        list.addFilter("hb_konto_id = " + this.getHbKonto().getID());
+        list.addFilter("mandant_id = " + this.getMandant().getID());
         if (!this.isNewObject())
           list.addFilter("id != " + this.getID()); // Natuerlich duerfen wir uns selbst nicht finden ;)
         if (list.hasNext())


### PR DESCRIPTION
- Bei Kontoauswahl nur Geldkonten anzeigen.
- Kontozuordnung mit migireren. 
- Filter ging nicht bei McKoi