### PR TITLE
Die Steuer der Splithauptbuchung wurde nicht gelöscht

### DIFF
--- a/src/de/willuhn/jameica/fibu/gui/action/BuchungSplitNeu.java
+++ b/src/de/willuhn/jameica/fibu/gui/action/BuchungSplitNeu.java
@@ -58,6 +58,7 @@ public class BuchungSplitNeu implements Action
 	        buchung.setHabenKonto(hauptBuchung.getHabenKonto());
 	        buchung.setSollKonto(hauptBuchung.getSollKonto());
 	        buchung.setSteuer(hauptBuchung.getSteuer());
+	        buchung.setSteuerObject(hauptBuchung.getSteuerObject());
 	        buchung.setGeprueft(hauptBuchung.isGeprueft());
 	        
 	        //Betrag aller bisherigen SplitBuchungen berechnen, daraus den Restbetrag errechnen

--- a/src/de/willuhn/jameica/fibu/server/AbstractTransferImpl.java
+++ b/src/de/willuhn/jameica/fibu/server/AbstractTransferImpl.java
@@ -113,7 +113,10 @@ public abstract class AbstractTransferImpl extends AbstractDBObject implements T
 		Cache cache = Cache.get(Steuer.class,true);
 		return (Steuer) cache.get(o);
 	}
-	  
+	
+	if(getSollKonto() == null || getHabenKonto() == null)
+		return null;
+	
 	//Das zu verwendende Steruersammelkonto anhand des Steuersatzes ermitteln
     Steuer sSteuer = getSollKonto().getSteuer();
     Steuer hSteuer = getHabenKonto().getSteuer();

--- a/src/de/willuhn/jameica/fibu/server/BuchungImpl.java
+++ b/src/de/willuhn/jameica/fibu/server/BuchungImpl.java
@@ -104,8 +104,11 @@ public class BuchungImpl extends AbstractBaseBuchungImpl implements Buchung, Cus
       // Wenn vorhanden, die SplitHauptbuchung speichern um die Steuer/Hilfsbuchungen zu entfernen
       if(hauptbuchung != null && hauptbuchung.getSteuer() >= 0.01d)
       {
-          hauptbuchung.setBetrag(hauptbuchung.getBruttoBetrag());
+    	  double brutto = hauptbuchung.getBruttoBetrag();
+          hauptbuchung.setBetrag(brutto);
+          hauptbuchung.setBruttoBetrag(brutto);
           hauptbuchung.setSteuer(0);
+          hauptbuchung.setSteuerObject(null);
           hauptbuchung.store();
       }
       


### PR DESCRIPTION
-Die Steuer der Splithauptbuchung wurde nicht gelöscht
-Fehler neue Buchung behoben